### PR TITLE
Pip installable Fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
-.. image:: GeomFuMlogo.png
-  :width: 800
-  :alt: GeomFuM logo
+.. image:: https://raw.githubusercontent.com/3diglab/geomfum/main/GeomFuMlogo.png
+   :width: 800
+   :alt: GeomFuM logo
+
 **GeomFuM** is a Modular Python Package for Machine Learning with `Functional Maps <https://dl.acm.org/doi/10.1145/2185520.2185526>`_. 
 Have a look at our `Software Paper Preprint <https://drive.google.com/file/d/1zr7ml2QWEOOlS9S3imER_HBuvYwMm3oo/view?usp=sharing>`_.
 
@@ -23,16 +24,19 @@ Or the classic pipeline: ``clone + pip install``.
 Some functionality requires packages that are not published on PyPI and must be installed manually:
 
 - `Rematching`: 
+
 .. code-block:: bash
 
     pip install git+https://github.com/filthynobleman/rematching.git@python-binding
 
 - `Geopext`: 
+
 .. code-block:: bash
 
     pip install git+https://github.com/luisfpereira/geopext.git@2b7a7be1a8fdc6e5755e5f4bda88bc284065e829
 
 - `Polpo`: 
+
 .. code-block:: bash
 
     pip install git+https://github.com/geometric-intelligence/polpo.git@main
@@ -75,8 +79,11 @@ We welcome contributions from the community!
 If you have suggestions, bug reports, or want to improve the code or documentation, feel free to:
 
 - Open an issue
+
 - Submit a pull request
+
 - Improve or add new examples/notebooks
+
 
 Please follow our `contribution guidelines <https://dig-air.github.io/geomfum.github.io/contributing.html>`_ and adhere to best practices for clean, modular, and well-documented code.
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,23 @@ Or the classic pipeline: ``clone + pip install``.
 
 - Make sure all their requirements are installed.
 
-- For `pyRMT`, follow the instructions `here <https://github.com/filthynobleman/rematching/tree/python-binding>`_.
+Some functionality requires packages that are not published on PyPI and must be installed manually:
+
+- `Rematching`: 
+.. code-block:: bash
+
+    pip install git+https://github.com/filthynobleman/rematching.git@python-binding
+
+- `Geopext`: 
+.. code-block:: bash
+
+    pip install git+https://github.com/luisfpereira/geopext.git@2b7a7be1a8fdc6e5755e5f4bda88bc284065e829
+
+- `Polpo`: 
+.. code-block:: bash
+
+    pip install git+https://github.com/geometric-intelligence/polpo.git@main
+
 
 How to use
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,25 +31,20 @@ dependencies = [
     "meshio",
     "pyfmaps",
     "torch",
-    "geomstats@git+https://github.com/geomstats/geomstats.git@main",
+    "geomstats",
 ]
 
 [project.optional-dependencies]
 lapl = ["robust-laplacian", "libigl"]
 metric = ["networkx", "potpourri3d"]
 sampling = ["pymeshlab"]
-rematching = [
-    "Rematching@git+https://github.com/filthynobleman/rematching.git@python-binding",
-]
+rematching = []
 sinkhorn = ["POT"]
 opt = ["geomfum[lapl,metric,sampling,rematching,sinkhorn]"]
-fun = [
-    "geopext@git+https://github.com/luisfpereira/geopext.git@2b7a7be1a8fdc6e5755e5f4bda88bc284065e829",
-]
+fun = []
 test-scripts = ["nbformat", "nbconvert", "ipykernel", "ipython", "pyvista", "plotly"]
 test = [
     "pytest",
-    "polpo@git+https://github.com/geometric-intelligence/polpo.git@main",
     "geomfum[opt,test-scripts,plotting-all]",
 ]
 plotly = ["plotly", "nbformat"]


### PR DESCRIPTION
This PR updates the project configuration to make the library pip-installable from PyPI.

Removed polpo, rematching, and geopext from pyproject.toml since they are not currently distributed via PyPI.
Added documentation with instructions on how to manually install these packages if users need the associated functionality.

Updated README with clearer installation notes.

⚠️ Note: Full pip-based installation will be available once geomstats publishes a release that includes the required backends (@luisfpereira).